### PR TITLE
allow for standard Rubymine navigation to steps

### DIFF
--- a/lib/turnip/dsl.rb
+++ b/lib/turnip/dsl.rb
@@ -9,6 +9,12 @@ module Turnip
     def step(description, &block)
       Turnip::Steps.step(description, &block)
     end
+    
+    alias_method :Given, :step
+    alias_method :When, :step
+    alias_method :Then, :step
+    alias_method :And, :step
+    alias_method :But, :step
 
     def steps_for(tag, &block)
       if tag.to_s == "global"


### PR DESCRIPTION
This change allows for Rubymine to find the step definitions the way that is normally done using cucumber.  Without this, I have not been able to Ctrl+click to follow to the step definition from my feature files.